### PR TITLE
add `dnf`

### DIFF
--- a/mondoo_dictionary.txt
+++ b/mondoo_dictionary.txt
@@ -274,6 +274,7 @@ dmg
 dmi
 dmsetup
 dmz
+dnf
 dnssec
 DNSSEC
 DNT


### PR DESCRIPTION
Trying to make this PR green: https://github.com/mondoohq/mondoo-com/pull/690

[`dnf`](https://docs.fedoraproject.org/en-US/quick-docs/dnf/) was added to the README.