### PR TITLE
Add Sophos to dictionary

### DIFF
--- a/mondoo_dictionary.txt
+++ b/mondoo_dictionary.txt
@@ -1162,6 +1162,8 @@ SNMPv
 Snowsight
 SOA
 socketstats
+Sophos
+sophos
 sourced
 sourcerepo
 SPACECADET


### PR DESCRIPTION
Dear Mondoo team,

hope you had a good start into this new week!

Your spell-checking doesn't know the word ```Sophos``` at the moment. This PR fixes this issue.

Have a nice day and looking forward to your merge!

Kind regards
Tom

Tom Kretschmann
System Engineer DevOps
SVA System Vertrieb Alexander

----
🔗 https://github.com/mondoohq/cnspec-policies/pull/421/files

![image](https://github.com/user-attachments/assets/c681583d-0fca-403e-8fd6-ef8fe70499ba)
