### PR TITLE
Add PSIRT to dictionary

### DIFF
--- a/mondoo_dictionary.txt
+++ b/mondoo_dictionary.txt
@@ -1300,6 +1300,7 @@ Prozesserstellung
 psconfig
 PSKs
 PSOs
+PSIRT
 psp
 PSPs
 PTR


### PR DESCRIPTION
## Summary
- Adds `PSIRT` (Product Security Incident Response Team) to the Mondoo spellcheck dictionary
- Used in FortiGuard PSIRT references in cnspec FortiOS security policies

🤖 Generated with [Claude Code](https://claude.com/claude-code)